### PR TITLE
Added support of composite payload for TXT record

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -197,7 +197,7 @@ int main(string[] args)
 		string line;
 		if ((line = readln()) is null)
 		{
-			writeln("Uable to read stdin line");
+			writeln("Unable to read stdin line");
 			return EXIT_FAILURE;
 		}     
 

--- a/source/parser.d
+++ b/source/parser.d
@@ -243,9 +243,11 @@ dnsParserResult dnsParse(const ref ubyte[] input, ref dnsMessage myDnsMessage, b
 
 		else if (myResponseSection.responseType == dnsType.TXT)
 		{
-			string characterString = readCharacterString(input);
-			myResponseSection.responseElements ~= characterString;
-			myResponseSection.responseString = characterString;
+			while(inputPtr < oldInputPtr + myResponseSection.responseDataLength) {
+				string characterString = readCharacterString(input);
+				myResponseSection.responseElements ~= characterString;
+				myResponseSection.responseString ~= characterString;
+			}
 		}
 		
 		else if (myResponseSection.responseType == dnsType.CNAME 


### PR DESCRIPTION
Added support of composite payload for TXT record into `source/parser.d`: as you can see, the record consist of two quoted blocks, but not just only one.